### PR TITLE
chore: remove noscript for metrika

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,14 +19,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <noscript>
-      <div>
-        <img
-          src="https://mc.yandex.ru/watch/70656700"
-          style="position:absolute; left:-9999px;"
-          alt=""
-        />
-      </div>
-    </noscript>
   </body>
 </html>


### PR DESCRIPTION
This doesn't work, metrika's dashboard still shows red status