### PR TITLE
fix: send empty utm source when there's no #utm_source

### DIFF
--- a/src/core/trackers/MixpanelTracker.ts
+++ b/src/core/trackers/MixpanelTracker.ts
@@ -1,6 +1,5 @@
 import mixpanel from 'mixpanel-browser'
 import { createTracker, TrackerInterface } from './tracker-utils'
-import pickBy from 'lodash.pickby'
 import { URLUtils } from '../../URLUtils'
 
 const MIXPANEL_ID = process.env.REACT_APP_MIXPANEL_ID
@@ -11,16 +10,13 @@ export const MixpanelTracker: TrackerInterface = createTracker({
   },
 
   async identify(id: number, vkId: number): Promise<void> {
-    const userParams = pickBy(
-      {
-        'vk id': vkId,
-        'utm source': URLUtils.getHashParam('utm_source'),
-      },
-      (param) => param
-    )
+    const userParams = {
+      'vk id': vkId,
+      'utm source': URLUtils.getHashParam('utm_source') || '',
+    }
     mixpanel.identify(String(id))
-    mixpanel.people.set(userParams)
-    mixpanel.register(userParams)
+    mixpanel.people.set_once(userParams)
+    mixpanel.register_once(userParams)
   },
 
   async reachGoal(

--- a/src/core/trackers/PosthogTracker.ts
+++ b/src/core/trackers/PosthogTracker.ts
@@ -1,7 +1,6 @@
 import posthog from 'posthog-js'
 import { timeout } from 'promise-timeout'
 import { createTracker, TrackerInterface } from './tracker-utils'
-import pickBy from 'lodash.pickby'
 import { URLUtils } from '../../URLUtils'
 
 const POSTHOG_ID = process.env.REACT_APP_POSTHOG_ID
@@ -28,14 +27,13 @@ export const PosthogTracker: TrackerInterface = createTracker({
 
   async identify(id: number, vkId: number): Promise<void> {
     await waitForInit()
-    const userParams = pickBy(
-      {
-        'utm source': URLUtils.getHashParam('utm_source'),
-      },
-      (param) => param
-    )
-    posthog.identify(String(id), { vkId, ...userParams })
-    posthog.register(userParams)
+    const userParams = {
+      vkId,
+      'utm source': URLUtils.getHashParam('utm_source') || '',
+    }
+    posthog.identify(String(id))
+    posthog.people.set_once(userParams)
+    posthog.register_once(userParams)
   },
 
   async reachGoal(


### PR DESCRIPTION
Otherwise mixpanel shows undefined in utm_source
Don't override existing utm_source if come from another