### PR TITLE
fix: reset multiplayer results when start new multiplayer game

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -127,6 +127,10 @@ const App = ({
     [multiplayerGameDefRef, multiplayerSocket]
   )
 
+  useEffect(() => {
+    setMultiplayerFinishedItems([])
+  }, [multiplayerGameDef])
+
   const joinMultiplayerGame = useCallback(
     async (gameDefId) => {
       setLoadingMultiplayerGameDef(true)


### PR DESCRIPTION
Otherwise people in results stack indefinitely