### PR TITLE
feat: remove multiplayer feature flag

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -35,8 +35,6 @@ import MultiplayerResults, {
 import { ScoreboardUserInstance } from '../models/scoreboard-user-model'
 import { FinishedGameData } from '../websocket-data-types'
 import useStateRef from '../core/hooks/use-state-ref'
-import useFeatureFlag from '../core/hooks/use-feature-flag'
-import { MULTIPLAYER } from '../core/feature-flags'
 
 type Props = {
   user: UserInstance | null
@@ -73,7 +71,6 @@ const App = ({
     MultiplayerResultItem[]
   >([])
   const multiplayerSocket = useRef<JsonWebSocket | null>(null)
-  const { enabled: multiplayerEnabled } = useFeatureFlag(MULTIPLAYER)
 
   const joinedMultiplayerGame = useCallback(
     ({ instance }: { instance: GameDefinitionInstance }) => {
@@ -172,13 +169,13 @@ const App = ({
   )
 
   useEffect(() => {
-    if (!multiplayerEnabled) return
     const joinGameDefId = URLUtils.getHashParam('gid')
     if (joinGameDefId) {
       joinMultiplayerGame(joinGameDefId)
       setGameMode(GameModes.multi)
     }
-  }, [joinMultiplayerGame, multiplayerEnabled])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const onFinishGame = async (localBattle: GameInstance) => {
     const updatedBattle = await BattleService.getBattle(localBattle.id)

--- a/src/components/panels/Home.tsx
+++ b/src/components/panels/Home.tsx
@@ -10,8 +10,6 @@ import { AppService } from '../AppService'
 import { UserInstance } from '../../core/user-model'
 import Loader from '../helpers/Loader'
 import { NOTIFICATIONS_STATUSES } from '../../constants'
-import useFeatureFlag from '../../core/hooks/use-feature-flag'
-import { MULTIPLAYER } from '../../core/feature-flags'
 
 type Props = {
   onStartSingleGame(): void
@@ -26,7 +24,6 @@ const Home = ({
   onUpdateUser,
 }: Props): JSX.Element => {
   const [loading, setLoading] = useState(false)
-  const { enabled: multiplayerEnabled } = useFeatureFlag(MULTIPLAYER)
 
   const onSwitchNotifications = async (event) => {
     const { checked: newChecked } = event.target
@@ -73,17 +70,15 @@ const Home = ({
               Начать одиночную игру
             </Button>
           </Cell>
-          {multiplayerEnabled && (
-            <Cell>
-              <Button
-                size="xl"
-                onClick={onStartMultiplayerGame}
-                disabled={loading}
-              >
-                Играть с другом
-              </Button>
-            </Cell>
-          )}
+          <Cell>
+            <Button
+              size="xl"
+              onClick={onStartMultiplayerGame}
+              disabled={loading}
+            >
+              Играть с другом
+            </Button>
+          </Cell>
         </Div>
       </Group>
 

--- a/src/core/feature-flags.ts
+++ b/src/core/feature-flags.ts
@@ -1,1 +1,1 @@
-export const MULTIPLAYER = 'multiplayer'
+export {}


### PR DESCRIPTION
Fix issue when App was dismounted after loading of user
Because when user is loaded we add App wrapper (SplitFactory)
inside FeatureFlagProvider
And changing component parent dismounts component